### PR TITLE
CMake: Set COMPATIBILITY correctly

### DIFF
--- a/src/simplecmdiobase/CMakeLists.txt
+++ b/src/simplecmdiobase/CMakeLists.txt
@@ -48,7 +48,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     SimpleCmdioBaseConfigVersion.cmake
     VERSION ${PACKAGE_VERSION}
-    COMPATIBILITY SameMinorVersion
+    COMPATIBILITY SameMajorVersion
     )
 
 # configure *Config.cmake


### PR DESCRIPTION
Not only that SameMinorVersion makes no sense - elser versions of cmake don't
support it.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>