### PR TITLE
Revert "cmdclient: send expected response length as a part of response"

### DIFF
--- a/src/simpleautorun/cmdhandlerfile.cpp
+++ b/src/simpleautorun/cmdhandlerfile.cpp
@@ -234,26 +234,16 @@ void CmdHandlerFile::SelectSocket(QTcpSocket *pSocket)
 void CmdHandlerFile::OnReceive()
 {
     if(m_pCurrSocket) {
-        //If response is longer than 32768 bytes, then it is received in multiple packets
-        //so, we use first parameter as the expected length of the response in bytes
-
-        if (m_strLastReceivedExternal.isEmpty()) {
-            expectedResponseLength = m_pCurrSocket->read(sizeof(qint64)).toLongLong();
+        m_strLastReceivedExternal = m_pCurrSocket->readAll();
+        m_strLastReceivedExternal.replace("\n", "");
+        bool bError = m_strLastReceivedExternal.contains(",ERROR", Qt::CaseInsensitive);
+        LogMsg(QStringLiteral("<-- ")+m_strLastReceivedExternal, bError ? LOG_COLOUR_RED : LOG_COLOUR_GREEN);
+        if(!m_bStopOnExternalError || !bError) {
+            emit cmdFinish();
         }
-        m_strLastReceivedExternal.append(m_pCurrSocket->readAll());
-
-        if(m_strLastReceivedExternal.length() == expectedResponseLength) {
-            m_strLastReceivedExternal.replace("\n", "");
-            bool bError = m_strLastReceivedExternal.contains(",ERROR", Qt::CaseInsensitive);
-            LogMsg(QStringLiteral("<-- ")+m_strLastReceivedExternal, bError ? LOG_COLOUR_RED : LOG_COLOUR_GREEN);
-            if(!m_bStopOnExternalError || !bError) {
-                emit cmdFinish();
-            }
-            else {
-                LogMsg(QStringLiteral("Abort on external error!"), LOG_COLOUR_RED);
-                emit kill(-1);
-            }
-            expectedResponseLength = 0;
+        else {
+            LogMsg(QStringLiteral("Abort on external error!"), LOG_COLOUR_RED);
+            emit kill(-1);
         }
     }
 }

--- a/src/simpleautorun/cmdhandlerfile.h
+++ b/src/simpleautorun/cmdhandlerfile.h
@@ -34,7 +34,6 @@ private:
     QMap<QStringList::iterator, int /*loop count*/> m_MapActiveLoops;
     bool m_bStopOnExternalError;
     QString m_strLastReceivedExternal;
-    quint64 expectedResponseLength = 0;
 };
 
 #endif // CMDHANDLERFILE_H

--- a/src/simplecmdiobase/cmdclient.cpp
+++ b/src/simplecmdiobase/cmdclient.cpp
@@ -48,10 +48,6 @@ void QSimpleCmdClient::OnCmdFinish(QString strCmdResponse, QIODevice *pCookie)
             if(m_pCmdParser->GetCmdLog()) {
                 qInfo("%s/%i: %s", qPrintable(m_pCmdParser->GetParserName()), m_pCmdParser->GetListenPort(), qPrintable(dataResponse));
             }
-
-            //send response length as the first parameter of response
-            QString responseLength = QStringLiteral("%1").arg(dataResponse.length(), sizeof(qint64), 10, QLatin1Char('0'));
-            dataResponse.prepend(responseLength);
             m_pSocket->write(dataResponse.toUtf8());
         }
     }


### PR DESCRIPTION
This reverts commit abdf11e3972a758ac1df432271ccc28b7e962868. This was a very specific implementation to overcome multiple packet response (happens when response length is more than 32768 bytes). Need to find a better way to handle this !